### PR TITLE
adding direnv to @console-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other unique benefits of the Meta-Plugins annex:
 |                   |                                                 |
 |**developer**      |[github-issues](https://github.com/Zsh-Packages/github-issues) (**package**), [github-issues-srv](https://github.com/Zsh-Packages/github-issues-srv) (**package**), [molovo/color](https://github.com/molovo/color), [molovo/revolver](https://github.com/molovo/revolver), [molovo/zunit](https://github.com/molovo/zunit), [voronkovich/gitignore](https://github.com/voronkovich/gitignore.plugin.zsh), [jonas/tig](https://github.com/jonas/tig)             |
 |                   |                                                 |
-|**console-tools**  |[dircolors-material](https://github.com/Zsh-Packages/dircolors-material) (**package**), sharkdp (**meta-plugin**), [ogham/exa](https://github.com/ogham/exa), [BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep), [jonas/tig](https://github.com/jonas/tig)|
+|**console-tools**  |[dircolors-material](https://github.com/Zsh-Packages/dircolors-material) (**package**), sharkdp (**meta-plugin**), [ogham/exa](https://github.com/ogham/exa), [BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep), [jonas/tig](https://github.com/jonas/tig), [direnv/direnv](https://github.com/direnv/direnv)|
 |                   |                                                 |
 |**fuzzy**          |[fzf](https://github.com/Zsh-Packages/fzf) (**package**), [fzy](https://github.com/Zsh-Packages/fzy) (**package**), [lotabout/skim](https://github.com/lotabout/skim), [peco/peco](https://github.com/peco/peco)                  |
 |**fuzzy-src**      |fzf-go, [fzy](https://github.com/Zsh-Packages/fzy) (**package**), skim-cargo, peco-go                    |

--- a/z-a-meta-plugins.plugin.zsh
+++ b/z-a-meta-plugins.plugin.zsh
@@ -48,7 +48,7 @@ Zinit_Annex_Meta_Plugins_Map=(
     # @zsh-users
     zsh-users   "zsh-users/zsh-syntax-highlighting zsh-users/zsh-autosuggestions zsh-users/zsh-completions"
     zsh-users+fast "zdharma-continuum/fast-syntax-highlighting zsh-users/zsh-autosuggestions zsh-users/zsh-completions"
-    
+
     # @zdharma
     zdharma     "zdharma-continuum/fast-syntax-highlighting zdharma-continuum/history-search-multi-word zdharma-continuum/zsh-diff-so-fancy"
     zdharma2    "zdharma-continuum/zconvey zdharma-continuum/zui zdharma-continuum/zflai"
@@ -67,7 +67,7 @@ Zinit_Annex_Meta_Plugins_Map=(
 
     # General console utilities. Includes also a LS_COLORS theme with
     # the Zsh completion configured.
-    console-tools "dircolors-material sharkdp ogham/exa BurntSushi/ripgrep jonas/tig"
+    console-tools "dircolors-material sharkdp ogham/exa BurntSushi/ripgrep jonas/tig direnv/direnv"
 
     # Fuzzy searchers (4 of them).
     fuzzy       "fzf fzy lotabout/skim peco/peco"
@@ -187,6 +187,9 @@ Zinit_Annex_Meta_Plugins_Config_Map=(
 
     # @woefe
     woefe/git-prompt.zsh      "$_std atload'_zsh_git_prompt_precmd_hook' nocd"
+
+    # @direnv
+    direnv/direnv             "$_std binary from'gh-r' mv'direnv* direnv' sbin'**/direnv(.exe|) -> direnv'"
 )
 
 # Snippets


### PR DESCRIPTION
## Description 
Adding the [direnv](https://github.com/direnv/direnv) tool to the console-tools annex

## Motivation and Context 
The annex is very useful, and this was already in the community collections. It just made sense to add this to this annex.

## Related Issue(s) 
n/a

## Usage examples 

```zsh

```

## How Has This Been Tested?
I wasn't sure how to test an annex.

## Types of changes 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: 

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
